### PR TITLE
Parameterise with master site

### DIFF
--- a/example/ExampleApp.hs
+++ b/example/ExampleApp.hs
@@ -17,11 +17,12 @@
 module ExampleApp where
 
 import ClassyPrelude.Yesod
-import SubApp qualified as Sub
+import SubApp hiding (Thing)
+import SubApp qualified
 
 data App = App
   { appHttpManager :: Manager
-  , appSubApp      :: Sub.SubApp App
+  , appSubApp      :: SubApp App
   }
 
 share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
@@ -32,7 +33,7 @@ Thing sql=things
 
 mkYesod "App" [parseRoutes|
 / HomeR GET
-/sub SubR {Sub.SubApp App} appSubApp
+/sub SubR {SubApp App} appSubApp
 |]
 
 getHomeR :: HandlerFor App Html
@@ -52,7 +53,7 @@ instance Yesod App where
           ^{pageBody p}
     |]
 
-instance Sub.YesodSubApp App where
+instance YesodSubApp App where
   type Thing App = ExampleApp.Thing
 
 instance RenderMessage App FormMessage where
@@ -62,7 +63,7 @@ instance HasHttpManager App where
   getHttpManager = appHttpManager
 
 makeFoundation :: IO App
-makeFoundation = App <$> newManager <*> liftIO Sub.newSubApp
+makeFoundation = App <$> newManager <*> liftIO newSubApp
 
 makeApplication :: App -> IO Application
 makeApplication foundation = do

--- a/src/SubApp.hs
+++ b/src/SubApp.hs
@@ -18,11 +18,16 @@ module SubApp
 import ClassyPrelude.Yesod
 import SubData
 
-instance (YesodSubApp master, authId ~ Thing master) => YesodSubDispatch (SubApp authId) master where
-  yesodSubDispatch = $(mkYesodSubDispatch resourcesSubApp)
+instance (Yesod master, YesodSubApp master)
+  => YesodSubDispatch (SubApp master) master where
+    yesodSubDispatch = $(mkYesodSubDispatch resourcesSubApp)
 
-getHelloR :: Yesod master => SubHandlerFor (SubApp (Thing master)) master Html
+getHelloR :: Yesod master => SubHandlerFor (SubApp master) master Html
 getHelloR = liftHandler $ defaultLayout [whamlet|<p>Hello, world!|]
 
-getThingR :: Yesod master => Show authId => authId -> SubHandlerFor (SubApp authId) master Html
-getThingR thingId = liftHandler $ defaultLayout [whamlet|<p>#{tshow thingId}|]
+getThingR ::
+     Yesod master
+  => YesodSubApp master
+  => Key (Thing master)
+  -> SubHandlerFor (SubApp master) master Html
+getThingR thingId = liftHandler $ defaultLayout [whamlet|<p>#{toPathPiece thingId}|]

--- a/src/SubData.hs
+++ b/src/SubData.hs
@@ -18,22 +18,15 @@ module SubData where
 
 import ClassyPrelude.Yesod
 
-data SubApp authId = SubApp
+data SubApp master = SubApp
 
-type MyConstraints a =
-  ( Eq a
-  , Show a
-  , Read a
-  , PathPiece a
-  )
-
-mkYesodSubData "(MyConstraints authId) => SubApp authId" [parseRoutes|
+mkYesodSubData "(YesodSubApp master) => SubApp master" [parseRoutes|
 /hello HelloR GET
-!/#{authId} ThingR GET
+!/#{Key (Thing master)} ThingR GET
 |]
 
-class (Yesod master, MyConstraints (Thing master)) => YesodSubApp master where
-  type Thing master
+class (PersistEntity (Thing master), PathPiece (Key (Thing master))) => YesodSubApp master where
+  type Thing master = t | t -> master
 
 newSubApp :: MonadIO m => m (SubApp site)
 newSubApp = pure SubApp

--- a/src/SubData.hs
+++ b/src/SubData.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -25,8 +25,11 @@ mkYesodSubData "(YesodSubApp master) => SubApp master" [parseRoutes|
 !/#{Key (Thing master)} ThingR GET
 |]
 
-class (PersistEntity (Thing master), PathPiece (Key (Thing master))) => YesodSubApp master where
-  type Thing master = t | t -> master
+class ( PersistEntity (Thing master)
+      , PathPiece (Key (Thing master))
+      ) => YesodSubApp master where
+
+  type Thing master
 
 newSubApp :: MonadIO m => m (SubApp site)
 newSubApp = pure SubApp

--- a/test/SubAppSpec.hs
+++ b/test/SubAppSpec.hs
@@ -2,6 +2,7 @@
 
 module SubAppSpec where
 
+import Database.Persist.Sql (toSqlKey)
 import TestImport
 
 spec :: Spec
@@ -18,6 +19,6 @@ spec = withApp $ do
     htmlAllContain "p" "Hello, world!"
 
   it "Loads the subsite's thing page" $ do
-    get $ SubR $ ThingR 3
+    get $ SubR $ ThingR $ toSqlKey 3
     statusIs 200
     htmlAllContain "p" "3"

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -6,7 +6,7 @@ module TestImport
 import ClassyPrelude as X hiding (Handler, delete, deleteBy, exp)
 import ExampleApp as X
 import Faker as X
-import SubApp as X
+import SubApp as X hiding (Thing)
 import System.Log.FastLogger.LoggerSet (newStdoutLoggerSet)
 import Test.Hspec as X
 import Yesod.Core.Dispatch (defaultMiddlewaresNoLogging)

--- a/yesod-subsite.cabal
+++ b/yesod-subsite.cabal
@@ -66,6 +66,7 @@ test-suite test
     , fakedata                         >=1.0
     , fast-logger
     , hspec                            >=2.7.10
+    , persistent
     , yesod-subsite
     , yesod-subsite-example
     , yesod


### PR DESCRIPTION
This is another version which parameterises with the master site directly rather than through the associated type defined in the typeclass. It's a little more similar to the example in the Yesod cookbook.